### PR TITLE
utilisation rate use engine count

### DIFF
--- a/include/nvtop/extract_gpuinfo_common.h
+++ b/include/nvtop/extract_gpuinfo_common.h
@@ -74,6 +74,7 @@ struct gpuinfo_static_info {
   unsigned n_shared_cores;
   unsigned l2cache_size;
   unsigned n_exec_engines;
+  unsigned engine_count;
   bool integrated_graphics;
   bool encode_decode_shared;
   unsigned char valid[(gpuinfo_static_info_count + CHAR_BIT - 1) / CHAR_BIT];

--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -337,6 +337,7 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
 
   uint64_t gfx_total_process_cycles = 0;
   uint64_t total_delta = 0;
+  unsigned int ec = gpu_info->static_info.engine_count ? : 1;
   unsigned int utilisation_rate;
   uint64_t max_freq_hz;
   double avg_delta_secs;
@@ -353,7 +354,7 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
 
   avg_delta_secs = ((double)total_delta / gpu_info->processes_count) / 1000000000.0;
   max_freq_hz = gpu_info->dynamic_info.gpu_clock_speed_max * 1000000;
-  utilisation_rate = (unsigned int)((((double)gfx_total_process_cycles) / (((double)max_freq_hz) * avg_delta_secs * 2)) * 100);
+  utilisation_rate = (unsigned int)((((double)gfx_total_process_cycles) / (((double)max_freq_hz) * avg_delta_secs * ec)) * 100);
   utilisation_rate = utilisation_rate > 100 ? 100 : utilisation_rate;
 
   SET_GPUINFO_DYNAMIC(&gpu_info->dynamic_info, gpu_util_rate, utilisation_rate);

--- a/src/extract_gpuinfo_mali_common.c
+++ b/src/extract_gpuinfo_mali_common.c
@@ -529,8 +529,10 @@ bool mali_common_parse_drm_fdinfo(struct gpu_info *info, FILE *fdinfo_file,
     }
   }
 
-  if (fid->engine_count)
-    SET_GPUINFO_PROCESS(process_info, gfx_engine_used, total_time);
+  if (fid->engine_count) {
+          SET_GPUINFO_PROCESS(process_info, gfx_engine_used, total_time);
+          info->static_info.engine_count = fid->engine_count;
+  }
 
   if (!client_id_set)
     return false;


### PR DESCRIPTION
- **Corrected proper nouns**
- **Info → information**
- **Clarify warning messages for Intel and MSM GPUs**
- **cmake: use check_linker_flag for checking linker flags**
- **split off linux-specific files from build**
- **apple: stubs for mac platform**
- **apple: add stubs for apple gpu support**
- **apple: make SIGPWR alias of SIGINFO**
- **apple: fetch device handles**
- **apple: add name and whether integrated to static device info**
- **apple: dynamic gpu utilization rate**
- **apple: dynamic memory info**
- **apple: implement fetching running processes**
- **apple: implement get_username_from_pid**
- **apple: implement get_process_info**
- **apple: implement get_command_from_pid**
- **MSM: Adds a couple GPU IDs**
- **readme: add some notes on Apple status**
- **Disable fdinfo callbacks for hidden gpus**
- **Fix compilation warnings**
- **Fix cache_entry for Intel and AMD GPU.**
- **Add support for Mali GPUs with the Panfrost driver**
- **Add display of additional GPU features**
- **Add support for Panfrost display of additional GPU properties**
- **Add support for post-fdinfo processing calculation of utilisation**
- **Add Panfrost support for manual calculation of engine utilisation**
- **Add support for Mali CSF GPUs with the Panthor driver.**
- **Refactor Panthor and Panfrost into library of shared code**
- **Fix related to pull request #248**
- **Save GPU info bar option to config file**
- **GPU info bar option in F2 menu**
- **cmake version upgrade docker script. 3.10 to 3.18**
- **add ascend extract gpu info code**
- **add ascend build script and README**
- **Toggle Panfrost's sysfs profiling hook after DRM handle is retrieved**
- **CMake dependency install for docker script**
- **fix issues for PR**
- **remove temp file**
- **Prevent potential Ascend device name buffer overflow**
- **interface_options: handle both XDG_CONFIG_HOME and HOME being unset**
- **Fix save w/o config location path**
- **Updated to fix errors in build to run on M2 Air**
- **Add support for Adreno 750**
- **MSM: Ignore speedbin in id if exact id isn't found**
- **Remove unnecessary code for Mac**
- **Bump version 3.1.0**
- **Remove import of kcmp**
- **AppImage build instruction & script**
- **AppImage script update**
- **Video encode/decode shared by static instance**
- **Support for recent NVML API**
- **Update readme's supported targets paragraph**
- **amgdpu: video code engine version extraction**
- **Update Docker image base to ubuntu 20.04**
- **Fix icon in appstream**
- **Fix screenshot URLs in appstream**
- **Add missing source file dependency for interfaceTests**
- **panfrost: replace debugfs profiling knob with sysfs**
- **Hide process list window**
- **Hide process list window**
- **Hide process list window**
- **Update make_appimage.sh**
- **Hide process list window**
- **Add i915 hwmon power values**
- **Add Intel Xe driver support**
- **Not sure these copy devices are needed**
- **Hide process list option in setup window & config file**
- **Fix tests with new parameter**
- **Re-introduce non-cached devices**
- **Fix potential null device access**
- **Don't require hwmon for AMDGPU**
- **Get per-process memory from fdinfo for Xe**
- **Revert back to the Xe driver device for the PCIe link**
- **docs: Add conda-forge feedstock to install instructions**
- **Add missed '&&"**
- **add basic support for raspberrypi gpu**
- **add process gpu usage support for raspberrypi**
- **move info read functions to utils and add some info from vcio device**
- **add decode info for h264 decode**
- **organize code**
- **print some debug messages**
- **fix strncat warning**
- **add the videocore support documentation**
- **fix some typos**
- **convert tid to pgid to match the process's pid.**
- **update README**
- **make appimage work on any linux system**
- **use newer ubuntu to build**
- **Add the necessary source file device_discovery_linux.c for V3D_SUPPORT in CMakeLists.txt**
- **Update CMakeLists.txt**
- **Fix compilation on FreeBSD and avoid crash existing (no hwmonDevice).**
- **Add Intel fan support Now present in kernel 6.12 https://patchwork.freedesktop.org/patch/610458/**
- **Add Intel temp support Currently being worked on in Intel's kernel branch: https://patchwork.freedesktop.org/series/137874/**
- **Fix process list randomly hiding in builds**
- **i915 has drm-total-local0 (now?) for memory Also fix a logic error**
- **Remove Intel GPU warning**
- **Include libdrm for builds with panfrost and panthor support**
- **Calculate power consumption based on energy usage**
- **Calculate power consumption for Xe driver**
- **v3d: migrate to standardised fdinfo info and add per-process gpu memory support.**
- **Avoid deref udev null device on unref**
- **Support BSD major/minor location**
- **Display fan RPM when max is not available**
- **Use bool, not NCURSES bool**
- **Add support for using i915 ioctls & implement memory usage using this**
- **Split i915 & xe, implement xe ioctls and memory usage**
- **Split fdinfo and implement GPU utilisation**
- **Add xe encode/decode support**
- **Add i915 compute and fix xe compute + edit readme**
- **Add gtt to memory usage**
- **Display total memory if available**
- **Apply suggestions from code review**
- **Include xe_drm.h until it mades it into libdrm**
- **Fix AMDGPU free memory calculation**
- **Add missing i915_drm.h structs/definitions**
- **Add missing declaration for Ubuntu 20.04**
- **Workaround broken Intel PCIe speeds**
- **Intel: Fix some very minor stuff**
- **Add Compile CI**
- **Add older ubuntu versions**
- **Add Intel to libdrm detection in CMakeLists.txt**
- **Update gentoo readme**
- **CI check ubuntu up to install**
- **Add missing va_end() call**
- **Improve PCI bridge checks**
- **Control reaches end of non-void function error. #350**
- **AMD: Fix encode/decode usage being dropped when it is shared**
- **Fix some compiler warnings**
- **Make shared encoder/decoder utilisation longer**
- **Fix build issue for ascend nvtop**
- **Add snapshot command to nvtop for scripting purposes**
- **Revert added spaces**
- **One more accidental formatting fix**
- **Remove fat fingered character**
- **Add Intel Xe driver temp support**
- **Convert output to json**
- **fix readme: make DESTDIR will prepend DESTDIR; switch to CMAKE_INSTALL_PREFIX**
- **adding TPU metrics via libtpuinfo**
- **Fix cpu fan selection**
- **Reorder percentage associativity and max to 100**
- **Fix division by zero on intel xe**
- **Bump version 3.2.0**
- **Fix the installed filename of the appstream metainfo**
- **Fix icon path**
- **Replace unmaintained ppa with quentiumyt**
- **[CI] Remove retired ubuntu runner**
- **Use fdinfo's engine count when refreshing utilisation rate**
